### PR TITLE
feat: Add toggle visibility and prevent duplicate favorites

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
         </div>
         <button id="new-quote-btn">New Quote</button>
         <button id="save-favorite-btn">Save Favorite</button>
+        <button id="show-favorites-btn">Show Favorites</button>
 
         <section class="favorites-section">
             <h2>Favorite Quotes</h2>

--- a/script.js
+++ b/script.js
@@ -2,7 +2,9 @@ const quoteText = document.getElementById('quote-text');
 const quoteAuthor = document.getElementById('quote-author');
 const newQuoteBtn = document.getElementById('new-quote-btn');
 const saveFavoriteBtn = document.getElementById('save-favorite-btn');
+const showFavoritesBtn = document.getElementById('show-favorites-btn');
 const favoritesList = document.getElementById('favorites-list');
+const favoritesSection = document.querySelector('.favorites-section');
 
 async function getQuote() {
   const apiUrl = 'https://api.api-ninjas.com/v1/quotes';
@@ -33,8 +35,17 @@ function displayQuote(quotes) {
 
 function saveFavorite() {
   const favorites = JSON.parse(localStorage.getItem('favoriteQuotes')) || [];
+  const currentQuoteText = quoteText.textContent;
+
+  const isDuplicate = favorites.some(fav => fav.quote === currentQuoteText);
+
+  if (isDuplicate) {
+    alert('This quote is already in your favorites!');
+    return;
+  }
+
   const currentQuote = {
-    quote: quoteText.textContent,
+    quote: currentQuoteText,
     author: quoteAuthor.textContent
   };
   favorites.push(currentQuote);
@@ -59,3 +70,6 @@ displayFavorites();
 // Event Listeners
 newQuoteBtn.addEventListener('click', getQuote);
 saveFavoriteBtn.addEventListener('click', saveFavorite);
+showFavoritesBtn.addEventListener('click', () => {
+  favoritesSection.classList.toggle('show');
+});

--- a/style.css
+++ b/style.css
@@ -46,3 +46,12 @@ button {
 button:hover {
     background-color: rgba(255, 255, 255, 0.1);
 }
+
+.favorites-section {
+    display: none;
+    margin-top: 2rem;
+}
+
+.favorites-section.show {
+    display: block;
+}


### PR DESCRIPTION
This commit introduces two improvements to the favorite quotes functionality:

1.  **Toggle Visibility of Favorites:**
    -   Adds a "Show Favorites" button to the UI.
    -   The favorites list is now hidden by default.
    -   Clicking the new button toggles the visibility of the favorites list.

2.  **Prevent Duplicate Favorites:**
    -   The logic for saving a favorite quote now checks if the quote already exists in the list.
    -   If the quote is a duplicate, an alert is shown to the user, and the quote is not saved again.