### PR TITLE
feat: Add social media sharing functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,20 @@
             <p id="quote-text"></p>
             <p id="quote-author"></p>
         </div>
-        <button id="new-quote-btn">New Quote</button>
-        <button id="save-favorite-btn">Save Favorite</button>
-        <button id="show-favorites-btn">Show Favorites</button>
-        <button id="clear-favorites-btn">Clear Favorites</button>
+        <div class="button-group">
+            <button id="new-quote-btn">New Quote</button>
+            <button id="save-favorite-btn">Save Favorite</button>
+            <button id="show-favorites-btn">Show Favorites</button>
+            <button id="clear-favorites-btn">Clear Favorites</button>
+            <div class="share-container">
+                <button id="share-btn">Share</button>
+                <div id="share-options" class="share-menu">
+                    <a href="#" id="share-whatsapp">Share on WhatsApp</a>
+                    <a href="#" id="share-linkedin">Share on LinkedIn</a>
+                    <a href="#" id="share-facebook">Share on Facebook</a>
+                </div>
+            </div>
+        </div>
 
         <section class="favorites-section">
             <h2>Favorite Quotes</h2>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,13 @@ const clearFavoritesBtn = document.getElementById('clear-favorites-btn');
 const favoritesList = document.getElementById('favorites-list');
 const favoritesSection = document.querySelector('.favorites-section');
 
+// Share Elements
+const shareBtn = document.getElementById('share-btn');
+const shareOptions = document.getElementById('share-options');
+const shareWhatsapp = document.getElementById('share-whatsapp');
+const shareLinkedin = document.getElementById('share-linkedin');
+const shareFacebook = document.getElementById('share-facebook');
+
 // Modal Elements
 const modal = document.getElementById('custom-modal');
 const modalMessage = document.getElementById('modal-message');
@@ -82,6 +89,35 @@ function clearFavorites() {
   });
 }
 
+// --- Share Logic ---
+function shareQuote(platform, event) {
+  event.preventDefault();
+  const quote = quoteText.textContent;
+  const author = quoteAuthor.textContent;
+  const websiteUrl = 'https://ai-powered-quote-of-the-day.netlify.app/';
+  const shareText = `Check out this quote: "${quote}" - ${author}. Find more inspiration here:`;
+  const encodedText = encodeURIComponent(shareText);
+  const encodedUrl = encodeURIComponent(websiteUrl);
+  let finalUrl = '';
+
+  switch (platform) {
+    case 'whatsapp':
+      finalUrl = `https://api.whatsapp.com/send?text=${encodedText}%20${encodedUrl}`;
+      break;
+    case 'linkedin':
+      // Note: LinkedIn has a simpler text-based sharing URL now.
+      // The old 'shareArticle' is deprecated. The full text will be placed in the post body.
+      finalUrl = `https://www.linkedin.com/feed/?shareActive=true&text=${encodedText}%20${encodedUrl}`;
+      break;
+    case 'facebook':
+      finalUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedText}`;
+      break;
+  }
+
+  window.open(finalUrl, '_blank');
+}
+
+
 // --- Modal Logic ---
 
 function showModal(message, confirmCallback) {
@@ -120,6 +156,14 @@ showFavoritesBtn.addEventListener('click', () => {
     showFavoritesBtn.textContent = 'Show Favorites';
   }
 });
+
+shareBtn.addEventListener('click', () => {
+    shareOptions.classList.toggle('show');
+});
+
+shareWhatsapp.addEventListener('click', (e) => shareQuote('whatsapp', e));
+shareLinkedin.addEventListener('click', (e) => shareQuote('linkedin', e));
+shareFacebook.addEventListener('click', (e) => shareQuote('facebook', e));
 
 modalConfirmBtn.addEventListener('click', () => {
   if (onConfirmCallback) {

--- a/style.css
+++ b/style.css
@@ -110,3 +110,53 @@ button:hover {
     font-size: 1.1rem;
     line-height: 1.5;
 }
+
+/* Share Button Styles */
+.button-group {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.share-container {
+    position: relative;
+    display: inline-block;
+}
+
+.share-menu {
+    display: none; /* Hidden by default */
+    position: absolute;
+    bottom: 100%; /* Position above the button */
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: 10px;
+    width: max-content;
+    z-index: 100;
+
+    /* Glassmorphism Styles */
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    padding: 0.5rem;
+}
+
+.share-menu.show {
+    display: block;
+}
+
+.share-menu a {
+    display: block;
+    color: #FFFFFF;
+    text-decoration: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.share-menu a:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}


### PR DESCRIPTION
This commit introduces a social sharing feature, allowing users to share the current quote on WhatsApp, LinkedIn, and Facebook.

- **UI**: Adds a "Share" button and a hidden, glassmorphism-styled menu with share links to `index.html` and `style.css`.
- **Logic**: Implements a `shareQuote` function in `script.js` that:
    - Constructs a shareable text string with the quote and a link back to the app.
    - URL-encodes the content for safety.
    - Builds the correct, platform-specific URL for WhatsApp, LinkedIn, and Facebook.
    - Opens the share URL in a new tab.
- **Interaction**: The main "Share" button toggles the visibility of the menu, and clicking a share link triggers the `shareQuote` function.