### PR TITLE
feat: Add favicon to the application

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quote of the Day</title>
+    <link rel="icon" href="https://i.ibb.co/XxX8PksV/logo.png">
+    <link rel="apple-touch-icon" href="https://i.ibb.co/XxX8PksV/logo.png">
     <link rel="preconnect" href="https://rsms.me/">
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
This commit adds the official logo as the website's favicon to enhance brand identity and professional appearance.

- Adds a `<link rel="icon">` tag to the `<head>` of `index.html` for standard browsers.
- Adds a `<link rel="apple-touch-icon">` tag for correct display on Apple devices when saved to the home screen.
- Both tags point to the hosted logo URL as specified.